### PR TITLE
fix: skip the stale workflow from private repos

### DIFF
--- a/.github/workflows/sdk-stale.yml
+++ b/.github/workflows/sdk-stale.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   stale:
+    if: endsWith(github.repository, 'private') != true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v7


### PR DESCRIPTION
We don't need to run the stale workflow against the private repos.