### PR TITLE
Pin aws/ssm-getparameters-action to a SHA

### DIFF
--- a/actions/release-secrets/action.yml
+++ b/actions/release-secrets/action.yml
@@ -20,7 +20,7 @@ runs:
         audience: https://github.com/launchdarkly
         role-to-assume: ${{ inputs.aws_assume_role }}
         aws-region: us-east-1
-    - uses: dkershner6/aws-ssm-getparameters-action@v1
+    - uses: dkershner6/aws-ssm-getparameters-action@0fbd3a271ba44a5aa6a035c7746ffe4cf4eb04fe
       if: ${{ inputs.ssm_parameter_pairs != '' }}
       with:
         parameterPairs: ${{ inputs.ssm_parameter_pairs }}


### PR DESCRIPTION
Since `aws-ssm-getparameters-action` deals with secrets, it seems prudent to pin it to a SHA just in case the v1 tag is modified.