### PR TITLE
feat: add default-branch action

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains LaunchDarkly shared GitHub Actions and Workflows for ot
 | [publish-pages](./actions/publish-pages/README.md)     | Publishes documentation to Github Pages.   |
 | [release-secrets](./actions/release-secrets/README.md) | Retrieve secrets from AWS Secrets Manager. |
 | [contract-tests](./actions/contract-tests/README.md)   | Run SDK/SSE contract tests.                |
+| [default-branch](./actions/default-branch/README.md)   | Determines the default branch of the repo. |
 
 
 ## Workflows

--- a/actions/contract-tests/README.md
+++ b/actions/contract-tests/README.md
@@ -27,7 +27,7 @@ jobs:
         run: $TEST_SERVICE_BINARY $TEST_SERVICE_PORT 2>&1 &
         
         # Here's the actual usage of this action!
-      - uses: ./.github/actions/contract-tests
+      - uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1.0.0
         with:
           # Inform the test harness of test service's port.
           test_service_port: ${{ env.TEST_SERVICE_PORT }}

--- a/actions/default-branch/README.md
+++ b/actions/default-branch/README.md
@@ -1,0 +1,27 @@
+# Default Branch
+
+This action discovers the default branch of the repository (from Github's point of view). This is useful for
+running certain workflows only on the default branch, even if the workflow is checked into multiple branches.
+
+It might also be useful in package publishing - the motivating scenario for this action is only pushing Docker `latest`
+tags from the default branch. 
+
+
+# Example
+
+```yml
+jobs:
+  do-something:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: launchdarkly/gh-actions/actions/default-branch@default-branch-v1.0.0
+        id: default-branch
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Do something if we're on default
+        if: steps.default-branch.outputs.condition == 'true'
+        run: echo "We're on the default branch!"
+      - name: So what is the default branch, anyways? 
+        run: echo "The default branch is ${{ steps.default-branch.outputs.value }}"
+```

--- a/actions/default-branch/action.yml
+++ b/actions/default-branch/action.yml
@@ -1,0 +1,26 @@
+name: Default Branch
+description: "Checks if the current branch is the default branch"
+inputs:
+  token:
+    description: 'GitHub API token.'
+    required: true
+outputs:
+  value:
+    description: 'The default branch of the repo.'
+    value: ${{ steps.get-default-branch.outputs.value }}
+  condition:
+    description: "'true' if the current branch is the default branch of the repo."
+    value: ${{ steps.get-default-branch.outputs.value == github.ref_name }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get default branch
+      id: get-default-branch
+      shell: bash
+      run: |
+        repo=$(echo "${{ github.repository }}" | cut -d '/' -f  2)
+        owner=$(echo "${{ github.repository }}" | cut -d '/' -f  1)
+        default_branch=$(curl --silent --header "Authorization: token ${{ inputs.token }}" \
+          https://api.github.com/repos/$owner/$repo | jq -r '.default_branch')
+        echo "value=$default_branch" >> $GITHUB_OUTPUT

--- a/actions/default-branch/action.yml
+++ b/actions/default-branch/action.yml
@@ -18,6 +18,8 @@ runs:
     - name: Get default branch
       id: get-default-branch
       shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
       run: |
         repo=$(echo "${{ github.repository }}" | cut -d '/' -f  2)
         owner=$(echo "${{ github.repository }}" | cut -d '/' -f  1)

--- a/actions/default-branch/action.yml
+++ b/actions/default-branch/action.yml
@@ -21,6 +21,5 @@ runs:
       run: |
         repo=$(echo "${{ github.repository }}" | cut -d '/' -f  2)
         owner=$(echo "${{ github.repository }}" | cut -d '/' -f  1)
-        default_branch=$(curl --silent --header "Authorization: token ${{ inputs.token }}" \
-          https://api.github.com/repos/$owner/$repo | jq -r '.default_branch')
+        default_branch=$(gh api repos/$owner/$repo --jq '.default_branch')
         echo "value=$default_branch" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Adds an action that determines if the current branch is the "default" Github branch.

This can be useful when you want to run workflows only on the default branch (but have the yml checked into all branches.)

The action's return values are a stringly-typed bool (is current branch default) and a string (the default branch, in case you want to compare it to something else besides the current branch.)


TODO:
-  [ ] Test with actual workflow run (can't be tested locally with act)