### PR TITLE
fix: inject github token into contract test downloader script

### DIFF
--- a/actions/contract-tests/action.yml
+++ b/actions/contract-tests/action.yml
@@ -39,5 +39,8 @@ runs:
       run: |
         curl ${{ inputs.token != '' && format('-H "Authorization: Token {0}"', inputs.token) || '' }} -s https://raw.githubusercontent.com/launchdarkly/${{ inputs.repo }}/main/downloader/run.sh | bash
       env:
+        # The token is directly used in the first curl command above to obtain the downloader script, to avoid rate limiting.
+        # The token is then passed to the downloader script itself, so it can perform more API requests and hopefully avoid rate limiting again.
+        GITHUB_TOKEN: ${{ inputs.token }}
         VERSION: ${{ inputs.version }}
         PARAMS: -url http://localhost:${{ inputs.test_service_port }} -port ${{ inputs.test_harness_port }} ${{ inputs.extra_params }} ${{ inputs.debug_logging == 'true' && '-debug' || '' }} -stop-service-at-end


### PR DESCRIPTION
Depends on: https://github.com/launchdarkly/sdk-test-harness/pull/206