### PR TITLE
ci: add release-please support

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,17 @@
+# This isn't meant for usage in consuming repos. It's for releasing this repo's actions/workflows itself.
+
+name: Release Please
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          target-branch: ${{ github.ref_name }}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,6 @@
+{
+  "actions/contract-tests": "1.0.1",
+  "actions/publish-pages": "1.0.2",
+  "actions/release-secrets": "1.1.0",
+  "actions/sign-dlls": "1.0.0"
+}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,7 @@
   "actions/contract-tests": "1.0.1",
   "actions/publish-pages": "1.0.2",
   "actions/release-secrets": "1.1.0",
-  "actions/sign-dlls": "1.0.0"
+  "actions/sign-dlls": "1.0.0",
+  "actions/verify-hello-app": "1.0.1",
+  ".github/workflows": "1.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,4 @@
 {
-  "bootstrap-sha": "9dde55e8f7236929b2f6ca19687d60fb711b9af3",
   "separate-pull-requests": true,
   "include-component-in-tag": true,
   "include-v-in-tag": true,
@@ -26,10 +25,7 @@
     },
     ".github/workflows": {
       "release-type": "simple",
-      "package-name": "workflows",
-      "exclude-paths": [
-        "release-please.yml"
-      ]
+      "package-name": "workflows"
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,15 +20,16 @@
       "release-type": "simple",
       "package-name": "sign-dlls"
     },
-    "actions/verify-hello-apps": {
+    "actions/verify-hello-app": {
       "release-type": "simple",
-      "package-name": "verify-hello-apps",
-      "bump-minor-pre-major": true,
-      "prerelease": true
+      "package-name": "verify-hello-app"
     },
     ".github/workflows": {
       "release-type": "simple",
-      "package-name": "workflows"
+      "package-name": "workflows",
+      "exclude-paths": [
+        "release-please.yml"
+      ]
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,34 @@
+{
+  "bootstrap-sha": "9dde55e8f7236929b2f6ca19687d60fb711b9af3",
+  "separate-pull-requests": true,
+  "include-component-in-tag": true,
+  "include-v-in-tag": true,
+  "packages": {
+    "actions/contract-tests": {
+      "release-type": "simple",
+      "package-name": "contract-tests"
+    },
+    "actions/publish-pages": {
+      "release-type": "simple",
+      "package-name": "publish-pages"
+    },
+    "actions/release-secrets": {
+      "release-type": "simple",
+      "package-name": "release-secrets"
+    },
+    "actions/sign-dlls": {
+      "release-type": "simple",
+      "package-name": "sign-dlls"
+    },
+    "actions/verify-hello-apps": {
+      "release-type": "simple",
+      "package-name": "verify-hello-apps",
+      "bump-minor-pre-major": true,
+      "prerelease": true
+    },
+    ".github/workflows": {
+      "release-type": "simple",
+      "package-name": "workflows"
+    }
+  }
+}


### PR DESCRIPTION
I added the existing actions that have releases. 

For the workflows that live in `.github/workflows`, they will be released as a single entity because there's no good way of saying "just this file in the folder is the product". So, something like `uses: launchdarkly/gh-actions/.github/workflows/sdk-stale.yml@workflows-v1.0.0`.

Maybe we could do it with exclude paths but seems annoying.