### PR TITLE
feat(contract-tests): allow passing branch independently of version

### DIFF
--- a/actions/contract-tests/action.yml
+++ b/actions/contract-tests/action.yml
@@ -9,6 +9,10 @@ inputs:
     required: false
     description: "Version of the test harness"
     default: 'v2'
+  branch:
+    required: false
+    description: "Branch of the test harness"
+    default: 'v2'
   test_service_port:
     required: true
     description: "Port of the component under test."
@@ -37,7 +41,7 @@ runs:
     - name: 'Run Contract Tests'
       shell: bash
       run: |
-        curl ${{ inputs.token != '' && format('-H "Authorization: Token {0}"', inputs.token) || '' }} -s https://raw.githubusercontent.com/launchdarkly/${{ inputs.repo }}/${{ inputs.version }}/downloader/run.sh | bash
+        curl ${{ inputs.token != '' && format('-H "Authorization: Token {0}"', inputs.token) || '' }} -s https://raw.githubusercontent.com/launchdarkly/${{ inputs.repo }}/${{ inputs.branch }}/downloader/run.sh | bash
       env:
         # The token is directly used in the first curl command above to obtain the downloader script, to avoid rate limiting.
         # The token is then passed to the downloader script itself, so it can perform more API requests and hopefully avoid rate limiting again.


### PR DESCRIPTION
Realized this action doesn't work anymore for `sse-contract-tests`, because even if you specify `version: main` (since sse doesn't have a weird v2 branch), it will pass that version to the downloader script. 

Since there's no version called main, it fails.

This PR decouples the branch and the version parameter. So, should be able to specify:
```
version: v2
branch: main
```

This should be backwards compatible with any existing usage of the action. 
