### PR TITLE
feat: Add a validate-approvers action for use in LD GitHub repos

### DIFF
--- a/actions/validate-approvers/README.md
+++ b/actions/validate-approvers/README.md
@@ -1,0 +1,29 @@
+# Validate Approvers Action
+
+This action validates that at least one approver of a pull request belongs to the required team. For use in LaunchDarkly repositories to ensure all PRs are approved by a non-contingent LaunchDarkly employee.
+
+## Usage
+
+A GitHub Actions workflow that uses this action might look like this:
+```
+name: Require valid approvers
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  validate-approvers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/validate-approvers
+        if: github.event.review.state == 'approved'
+        with:
+          github-token: ${{ secrets.GH_PAT }} # Pass in a GitHub token with API access
+          repository-owner: "${{ github.repository_owner }}"
+          repository: "${{ github.repository }}"
+          pull-request-number: ${{ github.event.pull_request.number }}
+          required-team: "role-product-engineers" # ROLE - Product Engineers only consists of full-time LaunchDarkly employees
+
+```

--- a/actions/validate-approvers/README.md
+++ b/actions/validate-approvers/README.md
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - uses: ./.github/actions/validate-approvers
+      - uses: launchdarkly/gh-actions/actions/validate-approvers
         if: github.event.review.state == 'approved'
         with:
           github-token: ${{ secrets.GH_PAT }} # Pass in a GitHub token with API access

--- a/actions/validate-approvers/action.yml
+++ b/actions/validate-approvers/action.yml
@@ -1,0 +1,46 @@
+name: 'Validate PR Approvers'
+description: 'Check if PR approver is a member of the required team'
+inputs:
+  github-token:
+    description: 'GitHub token for API access'
+    required: true
+  repository-owner:
+    description: 'The owner of the repository'
+    required: true
+  repository:
+    description: 'The name of the repository'
+    required: true
+  pull-request-number:
+    description: 'The number of the pull request'
+    required: true
+  required-team:
+    description: 'The name of the team that approvers must belong to'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Validate Approver Team Membership
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPOSITORY_OWNER: ${{ inputs.repository-owner }}
+        REPOSITORY: ${{ inputs.repository }}
+        PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
+        REQUIRED_TEAM: ${{ inputs.required-team }}
+      run: |
+        APPROVERS=$(gh api "repos/${REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}/reviews" -q '.[].user.login' 2>/dev/null || echo "") 
+      
+        VALID_APPROVER=0
+        for APPROVER in $APPROVERS; do
+          TEAM_MEMBER=$(gh api "orgs/${REPOSITORY_OWNER}/teams/${REQUIRED_TEAM}/memberships/${APPROVER}" -q '.state' 2>/dev/null || echo "") 
+
+          if [ "$TEAM_MEMBER" == "active" ]; then
+            VALID_APPROVER=1 
+            break
+          fi
+        done
+
+        if [ $VALID_APPROVER -eq 0 ]; then
+          echo "No valid approvers found in PR approvers list: $APPROVERS"
+          exit 1
+        fi


### PR DESCRIPTION
Intended for use in repos where contingent workers are allowed to make PRs to ensure that a full-time LD employee (ROLE - Product Engineers) has approved the PR.

Normally we'd use CODEOWNERS to ensure the appropriate team has approved a PR, but we can't really do that for ROLE - Product Engineers without tagging everyone on every PR. 

Workflows that use this reusable action should run at PR submit time and be marked as a required check in the repository. 