### PR TITLE
build: Drop release-please support for .github/workflows package

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,6 +4,5 @@
   "actions/publish-pages": "1.0.2",
   "actions/release-secrets": "1.2.0",
   "actions/sign-dlls": "1.0.0",
-  "actions/verify-hello-app": "2.0.1",
-  ".github/workflows": "1.0.0"
+  "actions/verify-hello-app": "2.0.1"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -27,10 +27,6 @@
     "actions/verify-hello-app": {
       "release-type": "simple",
       "package-name": "verify-hello-app"
-    },
-    ".github/workflows": {
-      "release-type": "simple",
-      "package-name": "workflows"
     }
   }
 }


### PR DESCRIPTION
Release please has decided it really wants to write a changelog for this
package. But we know from a [previous open issue][1], this isn't
possible.

We only have this as a package as a way to try and version control the
stale and lint title workflows. But the burden this is now causing is
less than the benefit we receive from automating the release of two
workflows which nearly never change.

Going forward, if we want to make changes to those workflows, we can
manually tag them like the good ole days. It will remind us to stay
thankful for the automations we do have. And once the [the issue][1] is
fixed, we can restore support.

[1]: https://github.com/googleapis/release-please-action/issues/938
