### PR TITLE
Update cache version for dependency-scan

### DIFF
--- a/actions/dependency-scan/evaluate-policy/action.yml
+++ b/actions/dependency-scan/evaluate-policy/action.yml
@@ -46,7 +46,7 @@ runs:
         fi
 
     - name: Cache Open Policy Agent
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: cache-opa
       with:
         path: /usr/local/bin/opa
@@ -61,7 +61,7 @@ runs:
 
     - name: Cache CycloneDX CLI tool
       if: inputs.artifacts-pattern != ''
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: cyclonedx-opa
       with:
         path: /usr/local/bin/cyclonedx


### PR DESCRIPTION
Update actions/cache from 4.0.2 (deprecated) to 4.2.0