### PR TITLE
chore: [SEC-7924] pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -17,6 +17,6 @@ jobs:
     name: Verify the PR title matches conventional commit spec.
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/actions/release-secrets/action.yml
+++ b/actions/release-secrets/action.yml
@@ -18,13 +18,13 @@ runs:
   using: composite
   steps:
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
       with:
         audience: https://github.com/launchdarkly
         role-to-assume: ${{ inputs.aws_assume_role }}
         aws-region: us-east-1
     - name: Load environment variables
-      uses: dkershner6/aws-ssm-getparameters-action@4fcb4872421f387a6c43058473acc1b22443fe13
+      uses: dkershner6/aws-ssm-getparameters-action@4fcb4872421f387a6c43058473acc1b22443fe13 # 4fcb4872421f387a6c43058473acc1b22443fe13
       if: ${{ inputs.ssm_parameter_pairs != '' }}
       with:
         parameterPairs: ${{ inputs.ssm_parameter_pairs }}

--- a/actions/sign-dlls/action.yml
+++ b/actions/sign-dlls/action.yml
@@ -34,7 +34,7 @@ runs:
         echo "PKCS11_CONFIG=/tmp/DigiCert One Signing Manager Tools/smtools-linux-x64/pkcs11properties.cfg" >> "$GITHUB_ENV"
 
     - name: Configure Digicert Secure Software Manager
-      uses: digicert/ssm-code-signing@v0.0.2
+      uses: digicert/ssm-code-signing@25dffce7023e3656c5ca688f96a2d7f3129fe2c0 # v0.0.2
       env:
         SM_API_KEY: ${{ env.DIGICERT_API_KEY }}
         SM_CLIENT_CERT_PASSWORD: ${{ env.DIGICERT_CLIENT_CERT_PASSWORD }}


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to full-length commit SHAs to prevent supply chain attacks.

Addresses findings from the [`third-party-action-not-pinned-to-commit-sha`](https://github.com/launchdarkly/semgrep-rules/blob/main/github-actions/third-party-action-not-pinned-to-commit-sha.yml) Semgrep rule.

## Test plan

- [ ] Verify CI passes with pinned action SHAs
<!-- ld-jira-link -->
---
Related Jira issue: [SEC-7924: Unpinned GitHub Actions remediation](https://launchdarkly.atlassian.net/browse/SEC-7924)
<!-- end-ld-jira-link -->