### PR TITLE
fix(dependency-scan): add option to fail if bom file is empty

### DIFF
--- a/actions/dependency-scan/generate-sbom/action.yml
+++ b/actions/dependency-scan/generate-sbom/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: 'Recurse mode suitable for mono-repos.'
     required: false
     default: 'true'
+  ensure-non-empty:
+    description: 'Fail if the generated BOM contains no components, which may indicate an upstream generation failure.'
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -59,6 +63,22 @@ runs:
       cdxgen "${args[@]}" -o "${{ steps.info.outputs.bom_file }}" ${{ inputs.project-directory }}
     env:
       FETCH_LICENSE: ${{ inputs.fetch-license }}
+
+  - name: Validate BOM is non-empty
+    if: inputs.ensure-non-empty == 'true'
+    shell: bash
+    run: |
+      bom_file="${{ steps.info.outputs.bom_file }}"
+      if [[ ! -f "$bom_file" ]]; then
+        echo "::error::BOM file '$bom_file' was not generated."
+        exit 1
+      fi
+      count=$(jq '.components | length' "$bom_file")
+      if [[ "$count" -eq 0 ]]; then
+        echo "::error::BOM file '$bom_file' contains no components. This may indicate an upstream generation failure."
+        exit 1
+      fi
+      echo "BOM validation passed: $count component(s) found."
 
   - name: Store Bill of Materials
     uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3


### PR DESCRIPTION
This PR will add an optional input for the generate-sbom action to fail if the generated file is empty.

By default, this option is not enabled so existing workflows should not be affected. The reason for this option is that we caught a few workflow runs that silently passed due to having no empty bom files and not due to not having any violations.

This option could be use to ensure that your workflow is actually scanning for licenses.

See https://github.com/launchdarkly/js-core/pull/1287

