### PR TITLE
feat: Composite action for synchronizing SDK snippets

### DIFF
--- a/actions/sync-snippets/README.md
+++ b/actions/sync-snippets/README.md
@@ -1,0 +1,65 @@
+# sync-snippets
+
+A composite action that pulls the canonical SDK code snippets from the latest
+[`launchdarkly/sdk-meta`](https://github.com/launchdarkly/sdk-meta) release and
+opens a sync PR against the calling repository. Used by gonfalon (and future
+consumers like `ld-docs-private`) to stay current with snippet changes without
+hand-editing.
+
+## Usage
+
+```yaml
+name: Sync SDK snippets
+on:
+  schedule:
+    - cron: '0 12 * * *'      # daily at 12:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write              # required for cosign keyless verification
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: launchdarkly/gh-actions/actions/sync-snippets@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## What it does
+
+1. Resolves the latest `snippets/vX.Y.Z` GitHub Release on `launchdarkly/sdk-meta` (override with `version:` if you need to pin or roll back).
+2. Downloads the platform-specific binary archive plus the cosign signature and certificate.
+3. Verifies the signature is keyless-signed by `launchdarkly/sdk-meta`'s `release-please` workflow on `main` via GitHub OIDC.
+4. Runs `snippets render --target=<adapter> --out=$GITHUB_WORKSPACE`. The binary embeds the canonical `sdks/` tree at build time — no separate snippet fetch.
+5. Opens (or updates) a pull request with the rewritten files. If `render` produced no diff, the action exits 0 without opening a PR.
+
+## Inputs
+
+| Name | Default | Description |
+|---|---|---|
+| `version` | `latest` | Release tag to install (e.g. `snippets/v0.3.0`). `latest` resolves to the most recent published `snippets/*` release. |
+| `target` | `ld-application` | Adapter target. `ld-application` for gonfalon. Future targets (e.g. `ld-docs`) plug in here. |
+| `branch` | `chore/sync-sdk-snippets` | Branch the action commits the rendered diff to. |
+| `pr-title` | `chore: sync SDK snippets` | Pull-request title. |
+| `pr-body` | (auto-generated) | Pull-request body. Defaults to a one-liner pointing at the upstream release notes. |
+| `pr-labels` | `sdk-snippets,automated-pr` | Comma-separated labels applied to the sync PR. |
+| `github-token` | (required) | Token used to download release assets and open the PR. The repo's default `GITHUB_TOKEN` is sufficient when the workflow has `contents: write` and `pull-requests: write`. |
+
+## Outputs
+
+| Name | Description |
+|---|---|
+| `version` | The release tag that was installed. |
+| `changes` | `true` if `render` produced any diff. |
+| `pr-number` | Pull-request number when one was opened or updated; empty otherwise. |
+
+## How the supply chain is locked down
+
+- **Signing identity is pinned to a specific workflow path.** `cosign verify-blob` checks `--certificate-identity-regexp` against `https://github.com/launchdarkly/sdk-meta/.github/workflows/release-please.yml@.+`. A token leaked from any other workflow in any other repo cannot produce a matching OIDC claim.
+- **No long-lived signing keys.** Each release signs itself using GitHub's OIDC token, so there is nothing to rotate, store, or accidentally check in.
+- **Snippet sources travel with the binary.** The CLI's `--sdks=` flag is optional; when omitted (the default for this action) it reads from `embed.FS`. Pinning a release version pins both the engine and the snippet content atomically.

--- a/actions/sync-snippets/README.md
+++ b/actions/sync-snippets/README.md
@@ -27,6 +27,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: launchdarkly/gh-actions/actions/sync-snippets@main
         with:
+          entrypoints: |
+            static/ld/components/getStarted
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
@@ -35,13 +37,14 @@ jobs:
 1. Resolves the latest `snippets/vX.Y.Z` GitHub Release on `launchdarkly/sdk-meta` (override with `version:` if you need to pin or roll back).
 2. Downloads the platform-specific binary archive plus the cosign signature and certificate.
 3. Verifies the signature is keyless-signed by `launchdarkly/sdk-meta`'s `release-please` workflow on `main` via GitHub OIDC.
-4. Runs `snippets render --target=<adapter> --out=$GITHUB_WORKSPACE`. The binary embeds the canonical `sdks/` tree at build time — no separate snippet fetch.
+4. Runs `snippets render --target=<adapter> --entrypoint=<dir>...` with one `--entrypoint` flag per non-empty line of the `entrypoints:` input. The binary embeds the canonical `sdks/` tree at build time — no separate snippet fetch. The renderer walks each entrypoint recursively, picks up files with extensions it understands (`.tsx`/`.jsx`/`.ts`/`.js`/`.mdx`) that contain the `SDK_SNIPPET:RENDER:` sentinel, and skips junk dirs (`node_modules`, `.git`, `dist`, `build`, ...).
 5. Opens (or updates) a pull request with the rewritten files. If `render` produced no diff, the action exits 0 without opening a PR.
 
 ## Inputs
 
 | Name | Default | Description |
 |---|---|---|
+| `entrypoints` | (required) | Newline-separated list of consumer-checkout directories the renderer should walk for snippet markers. Paths resolve against `$GITHUB_WORKSPACE`. |
 | `version` | `latest` | Release tag to install (e.g. `snippets/v0.3.0`). `latest` resolves to the most recent published `snippets/*` release. |
 | `target` | `ld-application` | Adapter target. `ld-application` for gonfalon. Future targets (e.g. `ld-docs`) plug in here. |
 | `branch` | `chore/sync-sdk-snippets` | Branch the action commits the rendered diff to. |

--- a/actions/sync-snippets/README.md
+++ b/actions/sync-snippets/README.md
@@ -18,7 +18,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write              # required for cosign keyless verification
 
 jobs:
   sync:
@@ -35,8 +34,8 @@ jobs:
 ## What it does
 
 1. Resolves the latest `snippets/vX.Y.Z` GitHub Release on `launchdarkly/sdk-meta` (override with `version:` if you need to pin or roll back).
-2. Downloads the platform-specific binary archive plus the cosign signature and certificate.
-3. Verifies the signature is keyless-signed by `launchdarkly/sdk-meta`'s `release-please` workflow on `main` via GitHub OIDC.
+2. Downloads the platform-specific binary archive from the release.
+3. Verifies the SLSA build-provenance attestation issued by `launchdarkly/sdk-meta`'s `release-please` workflow via `gh attestation verify`.
 4. Runs `snippets render --target=<adapter> --entrypoint=<dir>...` with one `--entrypoint` flag per non-empty line of the `entrypoints:` input. The binary embeds the canonical `sdks/` tree at build time — no separate snippet fetch. The renderer walks each entrypoint recursively, picks up files with extensions it understands (`.tsx`/`.jsx`/`.ts`/`.js`/`.mdx`) that contain the `SDK_SNIPPET:RENDER:` sentinel, and skips junk dirs (`node_modules`, `.git`, `dist`, `build`, ...).
 5. Opens (or updates) a pull request with the rewritten files. If `render` produced no diff, the action exits 0 without opening a PR.
 
@@ -63,6 +62,6 @@ jobs:
 
 ## How the supply chain is locked down
 
-- **Signing identity is pinned to a specific workflow path.** `cosign verify-blob` checks `--certificate-identity-regexp` against `https://github.com/launchdarkly/sdk-meta/.github/workflows/release-please.yml@.+`. A token leaked from any other workflow in any other repo cannot produce a matching OIDC claim.
-- **No long-lived signing keys.** Each release signs itself using GitHub's OIDC token, so there is nothing to rotate, store, or accidentally check in.
+- **Signing identity is pinned to a specific workflow path.** `gh attestation verify --signer-workflow launchdarkly/sdk-meta/.github/workflows/release-please.yml` checks the SLSA build-provenance subject against that exact workflow file. A token leaked from any other workflow in any other repo cannot produce a matching OIDC claim.
+- **No long-lived signing keys.** Each release attests itself using GitHub's OIDC token, so there is nothing to rotate, store, or accidentally check in. The attestation is published to `launchdarkly/sdk-meta`'s repo-level attestation store, not as a release asset.
 - **Snippet sources travel with the binary.** The CLI's `--sdks=` flag is optional; when omitted (the default for this action) it reads from `embed.FS`. Pinning a release version pins both the engine and the snippet content atomically.

--- a/actions/sync-snippets/action.yml
+++ b/actions/sync-snippets/action.yml
@@ -11,21 +11,10 @@ description: |
   compromised release token can't substitute a different binary without
   also faking the OIDC claim issued at build time.
 
-  Consumer-side wiring:
-
-      jobs:
-        sync:
-          runs-on: ubuntu-latest
-          permissions:
-            contents: write
-            pull-requests: write
-          steps:
-            - uses: actions/checkout@v4
-            - uses: launchdarkly/gh-actions/actions/sync-snippets@main
-              with:
-                entrypoints: |
-                  static/ld/components/getStarted
-                github-token: ${{ secrets.GITHUB_TOKEN }}
+  See actions/sync-snippets/README.md for a full consumer-side workflow
+  example. The action needs `contents: write` and `pull-requests: write`
+  permissions and the consumer's `GITHUB_TOKEN` passed via the
+  `github-token` input.
 
 inputs:
   version:

--- a/actions/sync-snippets/action.yml
+++ b/actions/sync-snippets/action.yml
@@ -1,0 +1,215 @@
+name: 'Sync SDK Snippets'
+description: |
+  Pulls the canonical SDK code snippets from the latest sdk-meta `snippets/` release
+  into the current consumer checkout (gonfalon, ld-docs-private), then opens or
+  updates a sync pull request when the rendered output differs from `main`.
+
+  The action is a thin wrapper around the `snippets` CLI. The CLI binary is
+  downloaded from sdk-meta's GitHub Releases as a cosign-signed artifact;
+  signing is keyless (GitHub OIDC) and verification pins the signing identity
+  to launchdarkly/sdk-meta's own `release-please` workflow, so a compromised
+  release token can't substitute a different binary without also faking the
+  OIDC claim.
+
+  Consumer-side wiring:
+
+      jobs:
+        sync:
+          runs-on: ubuntu-latest
+          permissions:
+            contents: write
+            pull-requests: write
+            id-token: write   # for cosign keyless verification
+          steps:
+            - uses: actions/checkout@v4
+            - uses: launchdarkly/gh-actions/actions/sync-snippets@main
+              with:
+                github-token: ${{ secrets.GITHUB_TOKEN }}
+
+inputs:
+  version:
+    description: |
+      Release tag to install, e.g. `snippets/v0.3.0`. The default `latest`
+      resolves to the most recent published release whose tag begins with
+      `snippets/`.
+    required: false
+    default: 'latest'
+  target:
+    description: |
+      Adapter target. `ld-application` for gonfalon (and any other consumer that
+      uses TSX render markers); future targets (e.g. `ld-docs`) plug in here.
+    required: false
+    default: 'ld-application'
+  branch:
+    description: 'Branch the action commits the rendered diff to.'
+    required: false
+    default: 'chore/sync-sdk-snippets'
+  pr-title:
+    description: 'Pull-request title.'
+    required: false
+    default: 'chore: sync SDK snippets'
+  pr-body:
+    description: |
+      Pull-request body. The default points at the upstream release notes for
+      the version being synced.
+    required: false
+    default: ''
+  pr-labels:
+    description: 'Comma-separated labels applied to the sync PR.'
+    required: false
+    default: 'sdk-snippets,automated-pr'
+  github-token:
+    description: |
+      Token used to download release assets and open the PR. Needs `contents:
+      write` and `pull-requests: write` on the consumer repo. The repo's default
+      `GITHUB_TOKEN` is sufficient.
+    required: true
+
+outputs:
+  version:
+    description: 'The sdk-meta snippets release tag that was actually installed.'
+    value: ${{ steps.resolve.outputs.tag }}
+  changes:
+    description: 'true if `snippets render` produced any diff against the working tree.'
+    value: ${{ steps.diff.outputs.changes }}
+  pr-number:
+    description: 'Pull-request number when a sync PR was opened or updated; empty otherwise.'
+    value: ${{ steps.cpr.outputs.pull-request-number }}
+
+runs:
+  using: composite
+  steps:
+    # 1. Resolve the version. `latest` queries the GitHub API for the most
+    #    recent release whose tag starts with `snippets/`. Any other value is
+    #    used verbatim — caller pins, action obeys.
+    - id: resolve
+      name: 'Resolve snippets release tag'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+        if [ "${{ inputs.version }}" = "latest" ]; then
+          tag=$(gh release list --repo launchdarkly/sdk-meta --limit 100 \
+                  --json tagName --jq '.[] | .tagName | select(startswith("snippets/"))' \
+                | head -n 1)
+          if [ -z "$tag" ]; then
+            echo "::error::no snippets/* release found in launchdarkly/sdk-meta"
+            exit 1
+          fi
+        else
+          tag="${{ inputs.version }}"
+        fi
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        echo "Using snippets release: $tag"
+
+    # 2. Resolve the platform's archive name. goreleaser names archives
+    #    snippets_<version>_<os>_<arch>.tar.gz, where <version> is the
+    #    bare semver (the `snippets/` tag prefix is stripped).
+    - id: archive
+      name: 'Resolve archive filename'
+      shell: bash
+      run: |
+        set -euo pipefail
+        case "$RUNNER_OS" in
+          Linux)  os=linux ;;
+          macOS)  os=darwin ;;
+          *) echo "::error::unsupported runner OS: $RUNNER_OS"; exit 1 ;;
+        esac
+        case "$RUNNER_ARCH" in
+          X64)   arch=amd64 ;;
+          ARM64) arch=arm64 ;;
+          *) echo "::error::unsupported runner arch: $RUNNER_ARCH"; exit 1 ;;
+        esac
+        version="${{ steps.resolve.outputs.tag }}"
+        version="${version#snippets/v}"
+        archive="snippets_${version}_${os}_${arch}.tar.gz"
+        echo "archive=$archive" >> "$GITHUB_OUTPUT"
+
+    # 3. Pull the archive, its detached signature, and the OIDC certificate
+    #    from the GitHub Release.
+    - name: 'Download release assets'
+      shell: bash
+      working-directory: ${{ runner.temp }}
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+        gh release download "${{ steps.resolve.outputs.tag }}" \
+          --repo launchdarkly/sdk-meta \
+          --pattern "${{ steps.archive.outputs.archive }}" \
+          --pattern "${{ steps.archive.outputs.archive }}.sig" \
+          --pattern "${{ steps.archive.outputs.archive }}.pem" \
+          --clobber
+
+    # 4. Install cosign and verify the signature. The identity regex pins
+    #    the signer to sdk-meta's release-please workflow on the main branch
+    #    — a token leaked from any other workflow couldn't produce a matching
+    #    OIDC claim.
+    - uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.7.0
+    - name: 'Verify signature'
+      shell: bash
+      working-directory: ${{ runner.temp }}
+      run: |
+        set -euo pipefail
+        archive="${{ steps.archive.outputs.archive }}"
+        cosign verify-blob \
+          --certificate "${archive}.pem" \
+          --signature   "${archive}.sig" \
+          --certificate-identity-regexp 'https://github\.com/launchdarkly/sdk-meta/\.github/workflows/release-please\.yml@.+' \
+          --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+          "$archive"
+
+    # 5. Extract the CLI and stage it on $PATH for the render step.
+    - name: 'Install CLI'
+      shell: bash
+      working-directory: ${{ runner.temp }}
+      run: |
+        set -euo pipefail
+        mkdir -p bin
+        tar -xzf "${{ steps.archive.outputs.archive }}" -C bin snippets
+        chmod +x bin/snippets
+        echo "$PWD/bin" >> "$GITHUB_PATH"
+
+    # 6. Render against the consumer checkout. `snippets` is now on $PATH.
+    #    The CLI loads the canonical sdks/ tree from the binary's embedded FS
+    #    — no separate snippet sources to fetch.
+    - name: 'Render snippets'
+      shell: bash
+      run: |
+        snippets version
+        snippets render --target='${{ inputs.target }}' --out="$GITHUB_WORKSPACE"
+
+    # 7. Detect whether render touched anything. Empty diff means the consumer
+    #    is already current; we exit cleanly with no PR.
+    - id: diff
+      name: 'Check for changes'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -n "$(git status --porcelain)" ]; then
+          echo "changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "changes=false" >> "$GITHUB_OUTPUT"
+          echo "Consumer tree is already in sync with ${{ steps.resolve.outputs.tag }}."
+        fi
+
+    # 8. Open or update a PR with the rendered diff. peter-evans/create-pull-
+    #    request handles both cases: pushes to the same branch, force-updates
+    #    on collisions, and leaves an existing PR alone if the diff is
+    #    identical to what's already proposed.
+    - id: cpr
+      name: 'Open or update sync PR'
+      if: steps.diff.outputs.changes == 'true'
+      uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # v7.0.6
+      with:
+        token: ${{ inputs.github-token }}
+        commit-message: 'chore: sync SDK snippets to ${{ steps.resolve.outputs.tag }}'
+        branch: ${{ inputs.branch }}
+        delete-branch: true
+        title: ${{ inputs.pr-title }}
+        body: |
+          ${{ inputs.pr-body != '' && inputs.pr-body || format('Syncs SDK snippets from upstream release [`{0}`](https://github.com/launchdarkly/sdk-meta/releases/tag/{0}).', steps.resolve.outputs.tag) }}
+
+          Generated by `launchdarkly/gh-actions/actions/sync-snippets@main`.
+        labels: ${{ inputs.pr-labels }}

--- a/actions/sync-snippets/action.yml
+++ b/actions/sync-snippets/action.yml
@@ -5,11 +5,11 @@ description: |
   updates a sync pull request when the rendered output differs from `main`.
 
   The action is a thin wrapper around the `snippets` CLI. The CLI binary is
-  downloaded from sdk-meta's GitHub Releases as a cosign-signed artifact;
-  signing is keyless (GitHub OIDC) and verification pins the signing identity
-  to launchdarkly/sdk-meta's own `release-please` workflow, so a compromised
-  release token can't substitute a different binary without also faking the
-  OIDC claim.
+  downloaded from sdk-meta's GitHub Releases and verified against a
+  GitHub-issued SLSA build provenance attestation; verification pins the
+  signing workflow to launchdarkly/sdk-meta's `release-please.yml`, so a
+  compromised release token can't substitute a different binary without
+  also faking the OIDC claim issued at build time.
 
   Consumer-side wiring:
 
@@ -19,7 +19,6 @@ description: |
           permissions:
             contents: write
             pull-requests: write
-            id-token: write   # for cosign keyless verification
           steps:
             - uses: actions/checkout@v4
             - uses: launchdarkly/gh-actions/actions/sync-snippets@main
@@ -115,9 +114,9 @@ runs:
         echo "tag=$tag" >> "$GITHUB_OUTPUT"
         echo "Using snippets release: $tag"
 
-    # 2. Resolve the platform's archive name. goreleaser names archives
-    #    snippets_<version>_<os>_<arch>.tar.gz, where <version> is the
-    #    bare semver (the `snippets/` tag prefix is stripped).
+    # 2. Resolve the platform's archive name. The release workflow names
+    #    archives snippets_<version>_<os>_<arch>.tar.gz, where <version> is
+    #    the bare semver (the `snippets/` tag prefix is stripped).
     - id: archive
       name: 'Resolve archive filename'
       shell: bash
@@ -138,9 +137,10 @@ runs:
         archive="snippets_${version}_${os}_${arch}.tar.gz"
         echo "archive=$archive" >> "$GITHUB_OUTPUT"
 
-    # 3. Pull the archive, its detached signature, and the OIDC certificate
-    #    from the GitHub Release.
-    - name: 'Download release assets'
+    # 3. Pull the archive from the GitHub Release. Attestations are
+    #    fetched separately by `gh attestation verify` from sdk-meta's
+    #    repo-level attestations — they aren't release assets.
+    - name: 'Download release archive'
       shell: bash
       working-directory: ${{ runner.temp }}
       env:
@@ -150,27 +150,23 @@ runs:
         gh release download "${{ steps.resolve.outputs.tag }}" \
           --repo launchdarkly/sdk-meta \
           --pattern "${{ steps.archive.outputs.archive }}" \
-          --pattern "${{ steps.archive.outputs.archive }}.sig" \
-          --pattern "${{ steps.archive.outputs.archive }}.pem" \
           --clobber
 
-    # 4. Install cosign and verify the signature. The identity regex pins
-    #    the signer to sdk-meta's release-please workflow on the main branch
-    #    — a token leaked from any other workflow couldn't produce a matching
-    #    OIDC claim.
-    - uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.7.0
-    - name: 'Verify signature'
+    # 4. Verify the SLSA build-provenance attestation. `--signer-workflow`
+    #    pins the signing workflow to sdk-meta's release-please.yml — a
+    #    token leaked from any other workflow couldn't produce a matching
+    #    OIDC claim. `gh` ships preinstalled on every GitHub-hosted
+    #    runner, so no separate install step is required.
+    - name: 'Verify attestation'
       shell: bash
       working-directory: ${{ runner.temp }}
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
       run: |
         set -euo pipefail
-        archive="${{ steps.archive.outputs.archive }}"
-        cosign verify-blob \
-          --certificate "${archive}.pem" \
-          --signature   "${archive}.sig" \
-          --certificate-identity-regexp 'https://github\.com/launchdarkly/sdk-meta/\.github/workflows/release-please\.yml@.+' \
-          --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-          "$archive"
+        gh attestation verify "${{ steps.archive.outputs.archive }}" \
+          --repo launchdarkly/sdk-meta \
+          --signer-workflow launchdarkly/sdk-meta/.github/workflows/release-please.yml
 
     # 5. Extract the CLI and stage it on $PATH for the render step.
     - name: 'Install CLI'

--- a/actions/sync-snippets/action.yml
+++ b/actions/sync-snippets/action.yml
@@ -80,8 +80,13 @@ runs:
   using: composite
   steps:
     # 1. Resolve the version. `latest` queries the GitHub API for the most
-    #    recent release whose tag starts with `snippets/`. Any other value is
-    #    used verbatim — caller pins, action obeys.
+    #    recent published release whose tag starts with `snippets/`. Drafts
+    #    and pre-releases are excluded — drafts especially matter because
+    #    sdk-meta's release pipeline cuts a draft, uploads assets, then
+    #    flips it to published. A `latest` query that catches the draft
+    #    window would point at a release whose assets and attestations may
+    #    not have been uploaded yet. Any non-`latest` value is used
+    #    verbatim — caller pins, action obeys.
     - id: resolve
       name: 'Resolve snippets release tag'
       shell: bash
@@ -91,10 +96,11 @@ runs:
         set -euo pipefail
         if [ "${{ inputs.version }}" = "latest" ]; then
           tag=$(gh release list --repo launchdarkly/sdk-meta --limit 100 \
+                  --exclude-drafts --exclude-pre-releases \
                   --json tagName --jq '.[] | .tagName | select(startswith("snippets/"))' \
                 | head -n 1)
           if [ -z "$tag" ]; then
-            echo "::error::no snippets/* release found in launchdarkly/sdk-meta"
+            echo "::error::no published snippets/* release found in launchdarkly/sdk-meta"
             exit 1
           fi
         else

--- a/actions/sync-snippets/action.yml
+++ b/actions/sync-snippets/action.yml
@@ -24,6 +24,8 @@ description: |
             - uses: actions/checkout@v4
             - uses: launchdarkly/gh-actions/actions/sync-snippets@main
               with:
+                entrypoints: |
+                  static/ld/components/getStarted
                 github-token: ${{ secrets.GITHUB_TOKEN }}
 
 inputs:
@@ -40,6 +42,16 @@ inputs:
       uses TSX render markers); future targets (e.g. `ld-docs`) plug in here.
     required: false
     default: 'ld-application'
+  entrypoints:
+    description: |
+      Newline-separated list of consumer-checkout directories the renderer
+      should walk for snippet markers. Paths are resolved relative to
+      $GITHUB_WORKSPACE (so a top-level `static/ld/components/getStarted` is
+      what gonfalon would pass). Each line becomes one `--entrypoint=` flag
+      to the CLI; the CLI walks each recursively, opens files with extensions
+      it understands (.tsx/.jsx/.ts/.js/.mdx), and skips junk dirs
+      (node_modules, .git, dist, build, ...).
+    required: true
   branch:
     description: 'Branch the action commits the rendered diff to.'
     required: false
@@ -173,12 +185,30 @@ runs:
 
     # 6. Render against the consumer checkout. `snippets` is now on $PATH.
     #    The CLI loads the canonical sdks/ tree from the binary's embedded FS
-    #    — no separate snippet sources to fetch.
+    #    — no separate snippet sources to fetch. Each line of the
+    #    `entrypoints:` input becomes one `--entrypoint=` flag (relative paths
+    #    resolve against $GITHUB_WORKSPACE).
     - name: 'Render snippets'
       shell: bash
+      env:
+        ENTRYPOINTS: ${{ inputs.entrypoints }}
       run: |
+        set -euo pipefail
         snippets version
-        snippets render --target='${{ inputs.target }}' --out="$GITHUB_WORKSPACE"
+        cd "$GITHUB_WORKSPACE"
+        args=()
+        while IFS= read -r line; do
+          # Strip surrounding whitespace; skip empty lines.
+          line="${line#"${line%%[![:space:]]*}"}"
+          line="${line%"${line##*[![:space:]]}"}"
+          [ -z "$line" ] && continue
+          args+=("--entrypoint=$line")
+        done <<< "$ENTRYPOINTS"
+        if [ ${#args[@]} -eq 0 ]; then
+          echo "::error::sync-snippets: at least one non-empty entrypoint must be provided"
+          exit 1
+        fi
+        snippets render --target="${{ inputs.target }}" "${args[@]}"
 
     # 7. Detect whether render touched anything. Empty diff means the consumer
     #    is already current; we exit cleanly with no PR.


### PR DESCRIPTION
## Summary

New composite action at `actions/sync-snippets/`. Consumers call it via `workflow_dispatch` (or a daily cron) to stay current with snippet changes published by `launchdarkly/sdk-meta`.

```yaml
on:
  workflow_dispatch:
  schedule: [ { cron: '0 12 * * *' } ]

permissions:
  contents: write
  pull-requests: write

jobs:
  sync:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: launchdarkly/gh-actions/actions/sync-snippets@main
        with:
          entrypoints: |
            static/ld/components/getStarted
          github-token: ${{ secrets.GITHUB_TOKEN }}
```

## How it works

1. Resolves the latest `snippets/v*` GitHub Release on `launchdarkly/sdk-meta` (override with `version:`).
2. Downloads the platform-specific archive (`snippets_<version>_<os>_<arch>.tar.gz`).
3. Verifies the SLSA build-provenance attestation via `gh attestation verify --signer-workflow launchdarkly/sdk-meta/.github/workflows/release-please.yml`. Sigstore-backed keyless OIDC under the hood, but no `cosign` install required — `gh` ships preinstalled on every GitHub-hosted runner.
4. Runs `snippets render --target=<adapter> --entrypoint=<dir>...` with one `--entrypoint=` flag per non-empty line of the `entrypoints:` input. The CLI walks each directory, picks up files containing the `SDK_SNIPPET:RENDER:` sentinel, and rewrites their marked regions in place. The binary embeds the canonical `sdks/` tree at build time, so there is nothing else to fetch.
5. Opens or updates a sync PR via `peter-evans/create-pull-request` when the render produced any diff. Empty diff → exit 0, no PR.

## Inputs / outputs

See `actions/sync-snippets/README.md`. Required: `entrypoints`, `github-token`. Everything else has a sensible default.

## How the supply chain is locked down

- **Signer pinned to a specific workflow path.** `gh attestation verify --signer-workflow launchdarkly/sdk-meta/.github/workflows/release-please.yml` rejects any artifact whose attestation was issued by a different workflow file. A token leaked from any other workflow in any other repo cannot produce a matching OIDC claim.
- **No long-lived signing keys.** Each release issues its own attestation via the GitHub-hosted Sigstore Fulcio CA against the workflow's OIDC token. Nothing to rotate, store, or accidentally check in.
- **Snippet sources travel with the binary.** The CLI's `--sdks=` flag is optional; when omitted (the default for this action) it reads from `embed.FS`. Pinning a release version pins both the engine and the snippet content atomically — no separate `sdks/` checkout step.

## Depends on

- launchdarkly/sdk-meta#404 ✅ (embed snippet sources + wire release pipeline) — merged.
- launchdarkly/sdk-meta#409 ✅ (replace goreleaser with `go build` + `actions/attest-build-provenance`) — merged. `snippets/v0.2.1` is the first published release this action can consume.

## End-to-end validation

Wired up in a private sandbox repo (`launchdarkly/learn-release-please`) via:

- `snippet-test/getStarted.tsx` — TSX file with two `SDK_SNIPPET:RENDER:` markers (`python-server-sdk/getting-started/mkdir` with no inputs, plus `.../install` with one optional `version` prop) seeded with `hash=0 version=0.0.0` placeholders.
- `.github/workflows/sync-snippets.yml` — `workflow_dispatch` referencing this action via `@rlamb/sync-snippets-action`.

[Sandbox PR #89](https://github.com/launchdarkly/learn-release-please/pull/89) merged the harness; the next dispatch (run [25190361399](https://github.com/launchdarkly/learn-release-please/actions/runs/25190361399)) ran green and the action opened [sandbox PR #91](https://github.com/launchdarkly/learn-release-please/pull/91), rewriting both markers with their `v0.2.1` content. Both render modes were exercised — bare-JSX-text (no inputs) and template-literal-with-ternary (optional input → `${version ? \`==${version}\` : ''}`).

## Test plan

- [x] Sandbox harness in `learn-release-please` opens a PR with rewritten markers (run #25190361399 → PR #91).
- [x] Both renderer paths exercised (bare text + template-literal-with-conditional).
- [x] `gh attestation verify` against the published v0.2.1 archive succeeds with the `--signer-workflow` pin.
- [ ] Re-dispatch on the sandbox after `peter-evans/create-pull-request` already opened a PR — expect: same branch updated, no second PR opened.
- [ ] Hand-edit one rendered region in the sandbox before re-running — expect: the action opens a PR that reverts the hand-edit (the hash mismatch is what `snippets verify` flags; `render` just re-renders).
- [ ] Pin `version:` to a non-existent tag — expect: clean failure at the resolve step.

## Known sharp edges

- `${{ ... }}` in the action manifest's `description:` field is template-evaluated at action-load time. Don't put example workflow snippets containing `secrets.*` into `description:` — those parse-fail with `Unrecognized named-value: 'secrets'`. Fixed in a0ad8bb by moving the inline example to README.md.
- Consumer repos must enable **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** for `peter-evans/create-pull-request` to open the sync PR; otherwise the PR-open step is silently blocked by the default `GITHUB_TOKEN` policy.