### PR TITLE
feat(sync-snippets): add raw-files target for manifest-driven consumers

### DIFF
--- a/actions/sync-snippets/README.md
+++ b/actions/sync-snippets/README.md
@@ -20,14 +20,25 @@ permissions:
   pull-requests: write
 
 jobs:
-  sync:
+  sync-tsx:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: launchdarkly/gh-actions/actions/sync-snippets@main
         with:
+          target: ld-application
           entrypoints: |
             static/ld/components/getStarted
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync-raw:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: launchdarkly/gh-actions/actions/sync-snippets@main
+        with:
+          target: raw-files
+          manifest: packages/sdk-info/extract.yaml
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
@@ -36,16 +47,19 @@ jobs:
 1. Resolves the latest `snippets/vX.Y.Z` GitHub Release on `launchdarkly/sdk-meta` (override with `version:` if you need to pin or roll back).
 2. Downloads the platform-specific binary archive from the release.
 3. Verifies the SLSA build-provenance attestation issued by `launchdarkly/sdk-meta`'s `release-please` workflow via `gh attestation verify`.
-4. Runs `snippets render --target=<adapter> --entrypoint=<dir>...` with one `--entrypoint` flag per non-empty line of the `entrypoints:` input. The binary embeds the canonical `sdks/` tree at build time — no separate snippet fetch. The renderer walks each entrypoint recursively, picks up files with extensions it understands (`.tsx`/`.jsx`/`.ts`/`.js`/`.mdx`) that contain the `SDK_SNIPPET:RENDER:` sentinel, and skips junk dirs (`node_modules`, `.git`, `dist`, `build`, ...).
+4. Runs `snippets render` against the consumer checkout. Two modes:
+   - **Marker-driven** (`target=ld-application` or `target=ld-docs`) — passes one `--entrypoint=<dir>` flag per non-empty line of `entrypoints:`. The renderer walks each directory recursively, picks up files with extensions it understands (`.tsx`/`.jsx`/`.ts`/`.js`/`.mdx`) that contain the `SDK_SNIPPET:RENDER:` sentinel, and rewrites the marked region.
+   - **Manifest-driven** (`target=raw-files`) — passes `--manifest=<path>` pointing at a YAML the consumer commits. Each `{id, path}` entry extracts a snippet body and writes it to `<manifest.out>/<path>`. Used by consumers that import snippet text via Vite `?raw` (e.g. gonfalon's `packages/sdk-info/`).
 5. Opens (or updates) a pull request with the rewritten files. If `render` produced no diff, the action exits 0 without opening a PR.
 
 ## Inputs
 
 | Name | Default | Description |
 |---|---|---|
-| `entrypoints` | (required) | Newline-separated list of consumer-checkout directories the renderer should walk for snippet markers. Paths resolve against `$GITHUB_WORKSPACE`. |
+| `target` | `ld-application` | Adapter target: `ld-application` (gonfalon TSX markers), `ld-docs` (ld-docs-private MDX markers), or `raw-files` (manifest-driven flat-file output). |
+| `entrypoints` | `''` | (Required for `target=ld-application` and `target=ld-docs`.) Newline-separated list of consumer-checkout directories the renderer should walk for snippet markers. Paths resolve against `$GITHUB_WORKSPACE`. Ignored for `target=raw-files`. |
+| `manifest` | `''` | (Required for `target=raw-files`.) Path to a raw-files manifest YAML, relative to `$GITHUB_WORKSPACE`. Ignored for marker-driven targets. |
 | `version` | `latest` | Release tag to install (e.g. `snippets/v0.3.0`). `latest` resolves to the most recent published `snippets/*` release. |
-| `target` | `ld-application` | Adapter target. `ld-application` for gonfalon. Future targets (e.g. `ld-docs`) plug in here. |
 | `branch` | `chore/sync-sdk-snippets` | Branch the action commits the rendered diff to. |
 | `pr-title` | `chore: sync SDK snippets` | Pull-request title. |
 | `pr-body` | (auto-generated) | Pull-request body. Defaults to a one-liner pointing at the upstream release notes. |

--- a/actions/sync-snippets/action.yml
+++ b/actions/sync-snippets/action.yml
@@ -267,7 +267,7 @@ runs:
     - id: cpr
       name: 'Open or update sync PR'
       if: steps.diff.outputs.changes == 'true'
-      uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # v7.0.6
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       with:
         token: ${{ inputs.github-token }}
         commit-message: 'chore: sync SDK snippets to ${{ steps.resolve.outputs.tag }}'

--- a/actions/sync-snippets/action.yml
+++ b/actions/sync-snippets/action.yml
@@ -110,10 +110,16 @@ runs:
       run: |
         set -euo pipefail
         if [ "${{ inputs.version }}" = "latest" ]; then
+          # Picking the first match inside jq instead of `… | head -n 1`
+          # avoids a SIGPIPE race: under `set -o pipefail`, `head` closing
+          # the pipe early causes `gh` to exit 141 on its next write,
+          # which fails the step intermittently depending on output
+          # buffering. `first // empty` returns "" cleanly when nothing
+          # matches.
           tag=$(gh release list --repo launchdarkly/sdk-meta --limit 100 \
                   --exclude-drafts --exclude-pre-releases \
-                  --json tagName --jq '.[] | .tagName | select(startswith("snippets/"))' \
-                | head -n 1)
+                  --json tagName \
+                  --jq 'map(.tagName | select(startswith("snippets/"))) | first // empty')
           if [ -z "$tag" ]; then
             echo "::error::no published snippets/* release found in launchdarkly/sdk-meta"
             exit 1

--- a/actions/sync-snippets/action.yml
+++ b/actions/sync-snippets/action.yml
@@ -26,8 +26,11 @@ inputs:
     default: 'latest'
   target:
     description: |
-      Adapter target. `ld-application` for gonfalon (and any other consumer that
-      uses TSX render markers); future targets (e.g. `ld-docs`) plug in here.
+      Adapter target. `ld-application` for gonfalon's TSX render markers,
+      `ld-docs` for ld-docs-private's MDX markers, `raw-files` for consumers
+      that import snippet text via Vite `?raw` (e.g. gonfalon's
+      `packages/sdk-info/`). Marker-driven targets (`ld-application`,
+      `ld-docs`) take `entrypoints:`; `raw-files` takes `manifest:`.
     required: false
     default: 'ld-application'
   entrypoints:
@@ -39,7 +42,19 @@ inputs:
       to the CLI; the CLI walks each recursively, opens files with extensions
       it understands (.tsx/.jsx/.ts/.js/.mdx), and skips junk dirs
       (node_modules, .git, dist, build, ...).
-    required: true
+
+      Required for `target=ld-application` and `target=ld-docs`. Ignored for
+      `target=raw-files` (use `manifest:` instead).
+    required: false
+    default: ''
+  manifest:
+    description: |
+      Path to a raw-files manifest YAML, relative to $GITHUB_WORKSPACE. The
+      manifest enumerates the snippet IDs to extract and where to write each
+      one (see the `raw-files` adapter docs in launchdarkly/sdk-meta). Used
+      only when `target=raw-files`; ignored otherwise.
+    required: false
+    default: ''
   branch:
     description: 'Branch the action commits the rendered diff to.'
     required: false
@@ -176,30 +191,54 @@ runs:
 
     # 6. Render against the consumer checkout. `snippets` is now on $PATH.
     #    The CLI loads the canonical sdks/ tree from the binary's embedded FS
-    #    — no separate snippet sources to fetch. Each line of the
-    #    `entrypoints:` input becomes one `--entrypoint=` flag (relative paths
-    #    resolve against $GITHUB_WORKSPACE).
+    #    — no separate snippet sources to fetch. Marker-driven targets
+    #    (ld-application, ld-docs) take one or more `--entrypoint=` flags
+    #    parsed from the newline-separated `entrypoints:` input; the
+    #    manifest-driven `raw-files` target takes a single `--manifest=`
+    #    pointing at a YAML the consumer commits.
     - name: 'Render snippets'
       shell: bash
       env:
+        TARGET: ${{ inputs.target }}
         ENTRYPOINTS: ${{ inputs.entrypoints }}
+        MANIFEST: ${{ inputs.manifest }}
       run: |
         set -euo pipefail
         snippets version
         cd "$GITHUB_WORKSPACE"
-        args=()
-        while IFS= read -r line; do
-          # Strip surrounding whitespace; skip empty lines.
-          line="${line#"${line%%[![:space:]]*}"}"
-          line="${line%"${line##*[![:space:]]}"}"
-          [ -z "$line" ] && continue
-          args+=("--entrypoint=$line")
-        done <<< "$ENTRYPOINTS"
-        if [ ${#args[@]} -eq 0 ]; then
-          echo "::error::sync-snippets: at least one non-empty entrypoint must be provided"
-          exit 1
-        fi
-        snippets render --target="${{ inputs.target }}" "${args[@]}"
+        case "$TARGET" in
+          raw-files)
+            if [ -z "$MANIFEST" ]; then
+              echo "::error::sync-snippets: target=raw-files requires manifest:"
+              exit 1
+            fi
+            if [ -n "$ENTRYPOINTS" ] && [ -n "$(echo "$ENTRYPOINTS" | tr -d '[:space:]')" ]; then
+              echo "::warning::sync-snippets: entrypoints: ignored when target=raw-files"
+            fi
+            snippets render --target=raw-files --manifest="$MANIFEST"
+            ;;
+          ld-application|ld-docs)
+            args=()
+            while IFS= read -r line; do
+              line="${line#"${line%%[![:space:]]*}"}"
+              line="${line%"${line##*[![:space:]]}"}"
+              [ -z "$line" ] && continue
+              args+=("--entrypoint=$line")
+            done <<< "$ENTRYPOINTS"
+            if [ ${#args[@]} -eq 0 ]; then
+              echo "::error::sync-snippets: target=$TARGET requires at least one non-empty entrypoint"
+              exit 1
+            fi
+            if [ -n "$MANIFEST" ]; then
+              echo "::warning::sync-snippets: manifest: ignored when target=$TARGET"
+            fi
+            snippets render --target="$TARGET" "${args[@]}"
+            ;;
+          *)
+            echo "::error::sync-snippets: unknown target $TARGET (expected ld-application, ld-docs, or raw-files)"
+            exit 1
+            ;;
+        esac
 
     # 7. Detect whether render touched anything. Empty diff means the consumer
     #    is already current; we exit cleanly with no PR.


### PR DESCRIPTION
## Summary

Extends the `sync-snippets` composite action to support the `raw-files` adapter target alongside the existing marker-driven (`ld-application`, `ld-docs`) targets.

Consumers that import snippet text via Vite's `?raw` import (e.g. gonfalon's `packages/sdk-info/`) need flat `.txt` files on disk, not marker comments embedded in source code — there's no marker to anchor a renderer to. The CLI's `raw-files` adapter (in `launchdarkly/sdk-meta`) already drives that mode via a YAML manifest the consumer commits; this PR just exposes it through the action.

## Behavior

- `target: ld-application` | `target: ld-docs` — requires `entrypoints:` (existing behavior, unchanged).
- `target: raw-files` — requires `manifest:`, ignores `entrypoints:` with a warning.
- Unknown `target:` — fails with a clear error.

`entrypoints:` is now optional at the schema level so a `target=raw-files` workflow doesn't have to pass an empty string; per-target validation lives in the run script so the error names the missing input concretely.

## Test plan

- [x] Action YAML parses (composite-action schema is line-validated by GitHub on push).
- [ ] Local end-to-end against the sdkinfo branch in gonfalon: clone, run `snippets render --target=raw-files --manifest=packages/sdk-info/extract.yaml` against the released `snippets/v0.2.1` binary, confirm the rendered `packages/sdk-info/src/snippets/` tree matches the canonical sdk-meta source byte-for-byte.
- [ ] Consumer workflow opens a sync PR when the manifest references a snippet whose body has changed upstream.