### PR TITLE
chore: Add sync-snippets to release-please config

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,5 +4,6 @@
   "actions/publish-pages": "1.0.3",
   "actions/release-secrets": "1.2.0",
   "actions/sign-dlls": "1.0.0",
+  "actions/sync-snippets": "0.0.0",
   "actions/verify-hello-app": "2.0.1"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,6 +23,10 @@
       "release-type": "simple",
       "package-name": "sign-dlls"
     },
+    "actions/sync-snippets": {
+      "release-type": "simple",
+      "package-name": "sync-snippets"
+    },
     "actions/verify-hello-app": {
       "release-type": "simple",
       "package-name": "verify-hello-app"


### PR DESCRIPTION
Currently we are pinning the action to a SHA, but it would still be nice to make releases so we can choose to use them in the future.