### PR TITLE
fix: Grant pull-requests:read so the lint-pr-title workflow works in internal repos

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -16,6 +16,8 @@ jobs:
   main:
     name: Verify the PR title matches conventional commit spec.
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:


### PR DESCRIPTION
## Summary

The reusable workflow at `.github/workflows/lint-pr-title.yml` fails on internal/private LaunchDarkly repos with `##[error]Resource not accessible by integration` (HTTP 403).

`amannn/action-semantic-pull-request` calls the GitHub REST API to fetch the PR title. Because the reusable workflow declares no `permissions:` block, it inherits the caller's default `GITHUB_TOKEN` scopes (`Contents`/`Metadata`/`Packages: read`). Public repos return PR data without `pull-requests` scope, but internal/private repos require `pull-requests: read`, so the action 403s.

This adds `permissions: pull-requests: read` to the `main` job, fixing all callers in one place.

- Jira: https://launchdarkly.atlassian.net/browse/SDK-2331
- Failing run: https://github.com/launchdarkly/rust-server-sdk-redis/actions/runs/25465853027/job/74823388143