### PR TITLE
feat: add dependency-scan reusable workflow

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -1,0 +1,39 @@
+name: Dependency Scan
+# Call this by uses: launchdarkly/gh-actions/.github/workflows/dependency-scan.yml@main
+
+on:
+  workflow_call:
+    inputs:
+      types:
+        description: 'SBOM types to generate (e.g., "nodejs" or "nodejs,go"). See https://cyclonedx.github.io/cdxgen/#/PROJECT_TYPES'
+        required: false
+        default: 'nodejs'
+        type: string
+      runs-on:
+        description: 'Runner specification'
+        required: false
+        default: 'ubuntu-latest'
+        type: string
+
+jobs:
+  generate-sbom:
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate SBOM
+        uses: launchdarkly/gh-actions/actions/dependency-scan/generate-sbom@main
+        with:
+          types: ${{ inputs.types }}
+
+  evaluate-policy:
+    runs-on: ${{ inputs.runs-on }}
+    needs:
+      - generate-sbom
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Evaluate SBOM Policy
+        uses: launchdarkly/gh-actions/actions/dependency-scan/evaluate-policy@main
+        with:
+          artifacts-pattern: bom*

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains LaunchDarkly shared GitHub Actions and Workflows for ot
 | Name                                                          | Description                                   |
 |---------------------------------------------------------------|-----------------------------------------------|
 | [contract-tests](./actions/contract-tests/README.md)          | Run SDK/SSE contract tests.                   |
+| [dependency-scan](./actions/dependency-scan/README.md)        | Generate SBOM and evaluate license policy.    |
 | [persistent-stores](./actions/persistent-stores/README.md)    | Start persistent stores on linux/mac/windows. |
 | [publish-pages](./actions/publish-pages/README.md)            | Publishes documentation to Github Pages.      |
 | [release-secrets](./actions/release-secrets/README.md)        | Retrieve secrets from AWS Secrets Manager.    |
@@ -14,10 +15,11 @@ This repository contains LaunchDarkly shared GitHub Actions and Workflows for ot
 | [verify-hello-apps](./actions/verify-hello-app/README.md)     | Run shared quality-checks for hello-apps.     |
 
 ## Workflows
-| Name                                                   | Description                                                            |
-|--------------------------------------------------------|------------------------------------------------------------------------|
-| [sdk-stale](./.github/workflows/sdk-stale.yml)         | Warns about stale issues, and then closes when required.               |
-| [lint-pr-title](./.github/workflows/lint-pr-title.yml) | Ensures PR titles follow [Conventional Commits][conventional-commits]. |
+| Name                                                                | Description                                                            |
+|---------------------------------------------------------------------|------------------------------------------------------------------------|
+| [dependency-scan](./.github/workflows/dependency-scan.yml)          | Generates SBOM and evaluates license policy.                           |
+| [sdk-stale](./.github/workflows/sdk-stale.yml)                      | Warns about stale issues, and then closes when required.               |
+| [lint-pr-title](./.github/workflows/lint-pr-title.yml)              | Ensures PR titles follow [Conventional Commits][conventional-commits]. |
 
 
 [conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
## Summary

Adds a reusable workflow (`.github/workflows/dependency-scan.yml`) that public repos can call to run dependency scanning. This mirrors the existing workflow in the private `common-workflows` repo but references the composite actions already in this repo (`actions/dependency-scan/generate-sbom` and `actions/dependency-scan/evaluate-policy`).

Motivation: public repos cannot call reusable workflows from private repos. This enables repos like `support-knowledge`, `slack-audiobot`, and `launchdarkly-contentful-app` to use the same dependency scanning pipeline.

Usage in a consuming repo:

```yaml
jobs:
  dependency-scan:
    uses: launchdarkly/gh-actions/.github/workflows/dependency-scan.yml@main
    with:
      types: 'generic'
```

Link to Devin session: https://app.devin.ai/sessions/49e588c5a7034c79a5451710f3f62a24
Requested by: @kparkinson-ld