### PR TITLE
chore: Add shared Renovate config presets for SDK repos

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,24 +27,31 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Update major version tags for components
-        if: ${{ steps.release.outputs.releases_created  == 'true'}}
+        if: ${{ steps.release.outputs.releases_created == 'true'}}
+        env:
+          RELEASE_OUTPUTS: ${{ toJson(steps.release.outputs) }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Get the paths that had releases created
-          PATHS_RELEASED='${{ steps.release.outputs.paths_released }}'
-
           # Parse the JSON array of released paths
-          echo "$PATHS_RELEASED" | jq -r '.[]' | while read -r path; do
-            # Get the tag name for this component
-            tag_name="${{ steps.release.outputs['${path}--tag_name'] }}"
+          echo "$RELEASE_OUTPUTS" | jq -r '.paths_released[]' | while read -r path; do
+            # Use jq to dynamically look up values using the path variable
+            tag_name=$(echo "$RELEASE_OUTPUTS" | jq -r ".[\"${path}--tag_name\"]")
+            major_version=$(echo "$RELEASE_OUTPUTS" | jq -r ".[\"${path}--major\"]")
+            
+            # Fail if tag_name or major_version are missing (they should always be set for released paths)
+            if [ "$tag_name" = "null" ] || [ -z "$tag_name" ]; then
+              echo "Error: Missing tag_name for path: $path"
+              exit 1
+            fi
+            if [ "$major_version" = "null" ] || [ -z "$major_version" ]; then
+              echo "Error: Missing major_version for path: $path"
+              exit 1
+            fi
 
             # Extract component name from tag name (e.g., contract-tests-v1.2.3 -> contract-tests)
             component=$(echo "$tag_name" | sed 's/-v[0-9].*//')
-
-            # Get the major version for this component
-            major_version="${{ steps.release.outputs['${path}--major'] }}"
 
             # Create component-specific major tag
             major_tag="${component}-v${major_version}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,8 +34,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Parse the JSON array of released paths
-          echo "$RELEASE_OUTPUTS" | jq -r '.paths_released[]' | while read -r path; do
+          # Parse the JSON string of released paths (paths_released is a JSON string, not an array)
+          echo "$RELEASE_OUTPUTS" | jq -r '.paths_released | fromjson | .[]' | while read -r path; do
             # Use jq to dynamically look up values using the path variable
             tag_name=$(echo "$RELEASE_OUTPUTS" | jq -r ".[\"${path}--tag_name\"]")
             major_version=$(echo "$RELEASE_OUTPUTS" | jq -r ".[\"${path}--major\"]")

--- a/renovate/sdk-javascript.json
+++ b/renovate/sdk-javascript.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>launchdarkly/gh-actions//renovate/sdk"],
+  "packageRules": [
+    {
+      "enabled": false,
+      "matchDatasources": ["npm"]
+    }
+  ]
+}

--- a/renovate/sdk-python.json
+++ b/renovate/sdk-python.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>launchdarkly/gh-actions//renovate/sdk"],
+  "packageRules": [
+    {
+      "enabled": false,
+      "matchDatasources": ["pypi"]
+    }
+  ]
+}

--- a/renovate/sdk-ruby.json
+++ b/renovate/sdk-ruby.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>launchdarkly/gh-actions//renovate/sdk"],
+  "packageRules": [
+    {
+      "enabled": false,
+      "matchDatasources": ["rubygems"]
+    }
+  ]
+}

--- a/renovate/sdk.json
+++ b/renovate/sdk.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "packageRules": [
+    {
+      "matchDepTypes": ["action"],
+      "matchPackagePatterns": ["^launchdarkly/gh-actions"],
+      "pinDigests": false
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true
+}


### PR DESCRIPTION
Tracked Internally: SDK-2476

## Summary
Only adding a few languages to prove out the concept first. If it works well we can add the rest as needed.

- Adds `renovate/sdk.json` — base preset for all SDK repos: extends `config:recommended` + `helpers:pinGitHubActionDigests`, disables SHA pinning for `launchdarkly/gh-actions` actions (since we own the tags), enables vulnerability alerts
- Adds `renovate/sdk-ruby.json` — extends base, disables `rubygems` updates
- Adds `renovate/sdk-python.json` — extends base, disables `pypi` updates

Consuming repos reference these as e.g. `github>launchdarkly/gh-actions//renovate/sdk-ruby` — a single extends line with no inline rules needed.

## Merge order
This PR must merge before the ruby-server-sdk and python-server-sdk PRs that reference these presets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)