### PR TITLE
fix: Restore HTTP readiness poll for Consul on Windows

### DIFF
--- a/actions/persistent-stores/action.yml
+++ b/actions/persistent-stores/action.yml
@@ -88,18 +88,24 @@ runs:
 
         Start-Process consul -ArgumentList 'agent', '-dev', '-http-port=${{ inputs.consul_port }}'
 
-        # consul members exits non-zero until the agent's HTTP API responds.
-        # In dev mode the leader is self-elected immediately on startup, so
-        # this is purely a process-readiness check.
-        $deadline = (Get-Date).AddSeconds(30)
-        $ready = $false
-        while ((Get-Date) -lt $deadline) {
-          consul members -http-addr="http://127.0.0.1:${{ inputs.consul_port }}" 2>&1 | Out-Null
-          if ($LASTEXITCODE -eq 0) { $ready = $true; break }
+        # Start-Process returns immediately, so wait until the dev agent's HTTP
+        # API is up and serving (leader elected) before tests run.
+        $timeout = 30
+        $elapsed = 0
+        while ($elapsed -lt $timeout) {
+          try {
+            $response = Invoke-RestMethod -Uri 'http://127.0.0.1:${{ inputs.consul_port }}/v1/status/leader' -TimeoutSec 2
+            if ($response -and $response -ne '""') {
+              Write-Host "Consul is ready (leader: $response)"
+              break
+            }
+          } catch {}
+          Write-Host "Waiting for Consul to elect a leader... ($elapsed/$timeout seconds)"
           Start-Sleep -Seconds 1
+          $elapsed++
         }
-        if (-not $ready) {
-          Write-Error "Consul did not become ready within 30 seconds"
+        if ($elapsed -eq $timeout) {
+          Write-Error "Consul did not become ready within $timeout seconds"
           exit 1
         }
 


### PR DESCRIPTION
## Summary

The `consul members` readiness check introduced in #77 fails the Windows step on its first loop iteration, so this restores the previous HTTP readiness poll.

### Root cause

While the dev agent is still starting, `consul members` writes a connection-refused message to **stderr**:

```
consul : Error retrieving members: Get "http://127.0.0.1:8500/v1/agent/members...": dial tcp 127.0.0.1:8500: ...actively refused it
    + FullyQualifiedErrorId : NativeCommandError
##[error]Process completed with exit code 1.
```

The `2>&1` merge under the Actions PowerShell wrapper (which runs with `$ErrorActionPreference = 'Stop'`) turns that native-command stderr into a terminating `NativeCommandError`, killing the step on the very first iteration -- the retry loop never runs, and there was no `try`/`catch` to absorb it.

### Fix

Restore the `/v1/status/leader` HTTP poll. `Invoke-RestMethod` raises a *catchable* exception on connection-refused, which the `try`/`catch` swallows so the loop retries until the agent is ready (30s timeout, fail on timeout). This reverts only that last change to the Consul-for-Windows step; the `/noservice` install change from #77 is left intact.

Observed in [python-server-sdk#412 CI](https://github.com/launchdarkly/python-server-sdk/actions/runs/27145803075/job/80123072795).
