### PR TITLE
feat: Add 7-day minimum release age to shared Renovate preset

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,24 +27,31 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Update major version tags for components
-        if: ${{ steps.release.outputs.releases_created  == 'true'}}
+        if: ${{ steps.release.outputs.releases_created == 'true'}}
+        env:
+          RELEASE_OUTPUTS: ${{ toJson(steps.release.outputs) }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Get the paths that had releases created
-          PATHS_RELEASED='${{ steps.release.outputs.paths_released }}'
-
           # Parse the JSON array of released paths
-          echo "$PATHS_RELEASED" | jq -r '.[]' | while read -r path; do
-            # Get the tag name for this component
-            tag_name="${{ steps.release.outputs['${path}--tag_name'] }}"
+          echo "$RELEASE_OUTPUTS" | jq -r '.paths_released[]' | while read -r path; do
+            # Use jq to dynamically look up values using the path variable
+            tag_name=$(echo "$RELEASE_OUTPUTS" | jq -r ".[\"${path}--tag_name\"]")
+            major_version=$(echo "$RELEASE_OUTPUTS" | jq -r ".[\"${path}--major\"]")
+            
+            # Fail if tag_name or major_version are missing (they should always be set for released paths)
+            if [ "$tag_name" = "null" ] || [ -z "$tag_name" ]; then
+              echo "Error: Missing tag_name for path: $path"
+              exit 1
+            fi
+            if [ "$major_version" = "null" ] || [ -z "$major_version" ]; then
+              echo "Error: Missing major_version for path: $path"
+              exit 1
+            fi
 
             # Extract component name from tag name (e.g., contract-tests-v1.2.3 -> contract-tests)
             component=$(echo "$tag_name" | sed 's/-v[0-9].*//')
-
-            # Get the major version for this component
-            major_version="${{ steps.release.outputs['${path}--major'] }}"
 
             # Create component-specific major tag
             major_tag="${component}-v${major_version}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,8 +34,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Parse the JSON array of released paths
-          echo "$RELEASE_OUTPUTS" | jq -r '.paths_released[]' | while read -r path; do
+          # Parse the JSON string of released paths (paths_released is a JSON string, not an array)
+          echo "$RELEASE_OUTPUTS" | jq -r '.paths_released | fromjson | .[]' | while read -r path; do
             # Use jq to dynamically look up values using the path variable
             tag_name=$(echo "$RELEASE_OUTPUTS" | jq -r ".[\"${path}--tag_name\"]")
             major_version=$(echo "$RELEASE_OUTPUTS" | jq -r ".[\"${path}--major\"]")

--- a/renovate/sdk.json
+++ b/renovate/sdk.json
@@ -8,6 +8,7 @@
       "pinDigests": false
     }
   ],
+  "minimumReleaseAge": "7 days",
   "vulnerabilityAlerts": {
     "enabled": true
   },


### PR DESCRIPTION
## Summary

- Adds `minimumReleaseAge: "7 days"` to `renovate/sdk.json`, the shared base preset for all SDK repos
- Delays Renovate PRs until 7 days after a package version is published, giving the community time to surface issues or vulnerabilities before we act on an update
- Applies to all SDK repos that extend this preset (currently `ruby-server-sdk` and `python-server-sdk`)

This mirrors the intent of [launchdarkly/php-server-sdk#249](https://github.com/launchdarkly/php-server-sdk/pull/249), which added a 7-day Dependabot cooldown for the same reason.

Tracked Internally: SDK-2476
Ref: SEC-8058.

## Test plan

- [ ] Verify Renovate config validates at https://docs.renovatebot.com/config-validator/
- [ ] After merge, confirm Renovate does not immediately open PRs for packages released within the last 7 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)