### PR TITLE
fix: fail sign-dlls action when no matching DLLs are found

### DIFF
--- a/actions/sign-dlls/action.yml
+++ b/actions/sign-dlls/action.yml
@@ -46,7 +46,12 @@ runs:
         CONFIG_PATH: ${{ inputs.build_configuration_path }}
         DLL_NAME: ${{ inputs.dll_name }}
       run: |
-        for dll in $(find $CONFIG_PATH -name $DLL_NAME); do
+        dlls=$(find "$CONFIG_PATH" -name "$DLL_NAME")
+        if [ -z "$dlls" ]; then
+          echo "::error::No files matching '$DLL_NAME' found in '$CONFIG_PATH'"
+          exit 1
+        fi
+        for dll in $dlls; do
           echo "${dll}"
           smctl sign --keypair-alias key_573919999 --config-file="/tmp/DigiCert One Signing Manager Tools/smtools-linux-x64/pkcs11properties.cfg" --input "${dll}"
         done


### PR DESCRIPTION
## Summary

The `sign-dlls` action silently succeeds when `dll_name` doesn't match any files — the `find` returns nothing and the `for` loop body never executes. This allowed dotnet-eventsource to ship 3 releases without Authenticode signing due to a typo in the `dll_name` input (see https://github.com/launchdarkly/dotnet-eventsource/pull/121).

Added a guard that checks `find` results before the loop and fails with `::error::` if no DLLs are found. All current callers provide correct names, so no existing workflows will break.

Link to Devin session: https://app.devin.ai/sessions/226ed88b8e8a4434920f2d7e3a49ee61
Requested by: @kinyoklion